### PR TITLE
Add symlink to Readme file

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,1 @@
+../readme.txt


### PR DESCRIPTION
Fixing my other PR  #535 

To keep compatibility with WordPress plugin system and also has a markdown preview in GitHub, I have created a symlink to the readme.txt file.

I hope this can help you. Thanks for your work doing this amazing plugin.