### PR TITLE
Adding support for non-Apache web servers

### DIFF
--- a/modules/reviews/reviews_form.php
+++ b/modules/reviews/reviews_form.php
@@ -71,6 +71,25 @@ class SASWP_Reviews_Form {
         
 
         public function saswp_save_review_form_data(){
+            /**
+             * getallheaders() is supported only in Apache Web Server
+             * and not in other popular web servers like NGINX.
+             * 
+             * Create the function if not already present, following the code
+             * in https://www.php.net/manual/en/function.getallheaders.php#84262
+             */
+            if (!function_exists('getallheaders')) {
+                function getallheaders()
+                {
+                    $headers = [];
+                    foreach ($_SERVER as $name => $value) {
+                        if (substr($name, 0, 5) == 'HTTP_') {
+                            $headers[str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5)))))] = $value;
+                        }
+                    }
+                    return $headers;
+                }
+            }  
             
             $form_data = $_POST;                 
             $headers = getallheaders();


### PR DESCRIPTION
# You can't call getallheaders() in NGINX and other popular web servers,
# so define the function in case it does not exist.