### PR TITLE
Add html_entity_decode for how_to description

### DIFF
--- a/modules/gutenberg/includes/class-gutenberg.php
+++ b/modules/gutenberg/includes/class-gutenberg.php
@@ -442,7 +442,7 @@ class SASWP_Gutenberg {
                     echo '</p>';
                 }                
                 if(isset($attributes['description'])){
-                    echo '<p>'.esc_attr($attributes['description']).'</p>';
+                    echo '<p>'.html_entity_decode(esc_attr($attributes['description'])).'</p>';
                 }
                                 
                 if(isset($attributes['items'])){


### PR DESCRIPTION
It should be the same as title and description for a single item in a how_to: 

```
                        echo '<strong class="saswp-how-to-step-name">'. html_entity_decode(esc_attr($item['title'])).'</strong>';
                        echo '<p class="saswp-how-to-step-text">'.html_entity_decode(esc_textarea($item['description'])).'</p>';
```

My use case is to allow `<code>` in it.