### PR TITLE
Avoid gutenberg_how_to schema appear in Category or Tag pages

### DIFF
--- a/output/function.php
+++ b/output/function.php
@@ -238,7 +238,7 @@ function saswp_get_all_schema_markup_output() {
                             $output .= ",";
                             $output .= "\n\n";
                         }
-                        if(!empty($gutenberg_how_to)){
+                        if(!empty($gutenberg_how_to) && is_singular()){
                         
                             $output .= saswp_json_print_format($gutenberg_how_to);   
                             $output .= ",";


### PR DESCRIPTION
If a gutenberg_how_to is added to a page with a category or a tag, the how to schema is also added to the category/tag page.

To reproduce, add a post with gutenberg_how_to, assign it a category, publish the post, go to the category page, check the HTML source, the how to schema is there but it shouldn't be

This PR should be able to avoid the how to schema appear in the category page.

(Note: I only fixed for the gutenberg howto, for other types of schema, this bug may also exist )