### PR TITLE
`rel="noopener"` for google review grid

### DIFF
--- a/modules/reviews/reviews_service.php
+++ b/modules/reviews/reviews_service.php
@@ -794,7 +794,7 @@ class saswp_reviews_service {
                        $html .= '<img loading="lazy" src="'.esc_url($value['saswp_reviewer_image']).'" width="56" height="56"/>';
                        $html .= '</div>';
                        $html .= '<div class="saswp-rc-nm">';
-                       $html .= '<a target="_blank" href="'.esc_url($value['saswp_review_link']).'">'.esc_attr($value['saswp_reviewer_name']).'</a>';
+                       $html .= '<a target="_blank" rel="noopener" href="'.esc_url($value['saswp_review_link']).'">'.esc_attr($value['saswp_reviewer_name']).'</a>';
                        $html .= saswp_get_rating_html_by_value($value['saswp_review_rating']);                       
                        $html .= '<span class="saswp-rc-dt">'.(isset($date_str['date']) ? esc_attr($date_str['date']): '' ).'</span>';
                        $html .= '</div>';
@@ -873,7 +873,7 @@ class saswp_reviews_service {
                 $html .= '<div class="saswp-rc-a">';
                 $html .= '<img loading="lazy" src="'.esc_url($value['saswp_reviewer_image']).'"/>';
                 $html .= '<div class="saswp-rc-nm">';
-                $html .= '<a target="_blank" href="'.esc_url($value['saswp_review_link']).'">'. esc_attr($value['saswp_reviewer_name']).'</a>';
+                $html .= '<a target="_blank" rel="noopener" href="'.esc_url($value['saswp_review_link']).'">'. esc_attr($value['saswp_reviewer_name']).'</a>';
                 $html .= '<span class="saswp-rc-dt">'.(isset($date_str['date']) ? esc_attr($date_str['date']): '' ).'</span>';
                 $html .= '</div>';
                 $html .= '</div>';


### PR DESCRIPTION
Good afternoon, everyone,

i have recently started working with the plugin and am very pleased with what you can do with it. good work!

Using Google lighthouse report I found a simple error/bestpractice approach that we could easily implement.
There is no rel="noopener" defined for the external links for the Google reviews in the grid system, can we change that?