### PR TITLE
Add support for Yet Another Star Rating Pro - User Reviews support.

### DIFF
--- a/output/function.php
+++ b/output/function.php
@@ -903,21 +903,20 @@ function saswp_ratency_rating_box_rating(){
 
 /**
  * Extracting the value of yet another star rating plugins on current post
- * @global type $sd_data
+ * @global type $sd_data, $post
  * @param type $id
  * @return type array
  */
 function saswp_extract_yet_another_stars_rating(){
-        
-    global $sd_data;    
+    global $sd_data, $post;
     $result = array();
 
     if(isset($sd_data['saswp-yet-another-stars-rating']) && $sd_data['saswp-yet-another-stars-rating'] == 1 && method_exists('YasrDatabaseRatings', 'getVisitorVotes') ){
-               
+
         $visitor_votes  = YasrDatabaseRatings::getVisitorVotes(false);
-         
+
         if( $visitor_votes && ($visitor_votes['sum_votes'] != 0 && $visitor_votes['number_of_votes'] != 0) ){
-           
+
             $average_rating = $visitor_votes['sum_votes'] / $visitor_votes['number_of_votes'];
             $average_rating = round($average_rating, 1);
 
@@ -925,22 +924,26 @@ function saswp_extract_yet_another_stars_rating(){
             $result['ratingCount'] = $visitor_votes['number_of_votes'];
             $result['ratingValue'] = $average_rating;  
             $result['bestRating']  = 5;
-            $result['worstRating'] = 1;                                                         
-            
+            $result['worstRating'] = 1;
+
             return $result;
-            
-        }else{
-            
-            return array();    
-            
+        } elseif ( method_exists('YasrCommentsRatingData', 'getCommentStats') ) {
+            $ratingData = new YasrCommentsRatingData;
+            $stats = $ratingData->getCommentStats($post->ID);
+            if ( isset($stats['n_of_votes']) && $stats['n_of_votes'] != 0 ) {
+                $result['@type']       = 'AggregateRating';
+                $result['ratingCount'] = $stats['n_of_votes'];
+                $result['ratingValue'] = $stats['average'];
+                $result['bestRating']  = 5;
+                $result['worstRating'] = 1;
+                return $result;
+            }
         }
-        
-    }else{
-        
-        return array();
-        
-    }                        
+
+    }
+    return array();
 }
+
 
 /**
  * Extracting the value of wpdiscuz plugins on current post


### PR DESCRIPTION
This feature in Yasr Pro actually leverages a meta tag in comments_meta

The patch extends the functionality of saswp_extract_yet_another_stars_rating to support this feature.

I've also cleaned up a couple of redundant else statements.