### PR TITLE
add trailing slash to Context URL

### DIFF
--- a/admin_section/common-function.php
+++ b/admin_section/common-function.php
@@ -2675,10 +2675,10 @@ function saswp_on_activation(){
 
 function saswp_context_url(){
     
-    $url = 'http://schema.org';
+    $url = 'http://schema.org/';
     
     if(is_ssl()){
-        $url = 'https://schema.org';
+        $url = 'https://schema.org/';
     }
     
     return $url;


### PR DESCRIPTION
- the `@context` property value currently lacks the trailing slash, such as:
  ```
    {"@context":"https://schema.org",
  ```
  instead of:
  ```
    {"@context":"https://schema.org/",
- although the schema.org site can properly handle the missing trailing slash, it would be good to change this to have a trailing slash by default, as it would then be a properly formed URL
- a discussion by the W3C working group handled this exact question: see https://lists.w3.org/Archives/Public/public-vocabs/2015Feb/0083.html
- CCing the associated ticket, where our graph harvesting instance is hitting this issue: https://github.com/iodepo/odis-arch/issues/82