### PR TITLE
Fixed the warning in error log

### DIFF
--- a/output/service.php
+++ b/output/service.php
@@ -8264,7 +8264,9 @@ Class saswp_output_service{
                 $image_alt     = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
 
                 $saswp_featured_image[$image_id]            = wp_get_attachment_image_src($image_id, 'full');            
-                $saswp_featured_image[$image_id]['caption'] = $image_alt ? $image_alt : '';
+
+                if( is_array($saswp_featured_image[$image_id]) && !empty($saswp_featured_image[$image_id]) )
+                    $saswp_featured_image[$image_id]['caption'] = $image_alt ? $image_alt : '';
 
             }
                 


### PR DESCRIPTION
Got warning in error log:  'PHP message: PHP Deprecated:  Automatic conversion of false to array is deprecated in /wp-content/plugins/schema-and-structured-data-for-wp/output/service.php on line 8263'