### PR TITLE
PHP 8.5 Fix For PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in schema-and-structured-data-for-wp/output/gutenberg.php on line 412

### DIFF
--- a/output/gutenberg.php
+++ b/output/gutenberg.php
@@ -407,10 +407,12 @@ function saswp_get_gutenberg_block_data($block){
             
             if($blocks){
 
-                foreach ( $blocks as $parse_blocks){
-                        $block_list[] = $parse_blocks['blockName'];
-                        $block_data[$parse_blocks['blockName']] = $parse_blocks;
+                foreach ($blocks as $parse_blocks) {
+                         $block_name = $parse_blocks['blockName'] ?? '';
+                         $block_list[] = $block_name;
+                         $block_data[$block_name] = $parse_blocks;
                 }
+
 
             }        
     }


### PR DESCRIPTION
When switching to PHP 8.5, the following deprecated warning is shown.

PHP Deprecated:  Using null as an array offset is deprecated, use an empty string instead in schema-and-structured-data-for-wp/output/gutenberg.php on line 412.

This can be fixed with the following pull request:

https://github.com/andy-1977/schema-and-structured-data-for-wp/commit/e81b7eeb4ce5370a78ef529bbdbc5030a24cb138